### PR TITLE
Lock dependences using glide

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,17 @@ jobs:
               cd scripts
               ./setup-test-db.sh
       - run:
-          name: Retrieving revel
-          command: go get github.com/revel/revel
+          name: Setup and install glide
+          command: |
+              wget https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz
+              tar xvfz glide-v0.13.1-linux-amd64.tar.gz -C $GOPATH/bin --strip-components=1 linux-amd64/glide
+              rm glide-v0.13.1-linux-amd64.tar.gz
       - run:
-          name: Retrieving revel (cmdline)
-          command: go get github.com/revel/cmd/revel
-      - run:
-          name: Retrieving mysql
-          command: go get github.com/go-sql-driver/mysql
+          name: Setup dependences
+          command: |
+              glide install
+              go install pingo/vendor/github.com/revel/cmd/revel
+              ln -s $(pwd)/vendor/github.com $GOPATH/src        # revel/cmd/revel is a bit special
       - run:
           name: Running revel tests
           command: revel test pingo

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 routes/
 conf/settings.json
 .idea/
+vendor/

--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ high-productivity web framework for the [Go language](http://www.golang.org/)
 
 ## Quick start
 
-Make sure you have a correct `$GOPATH` set (e.g. add `export GOPATH=$HOME/Go` to your `.bashrc`)
+Make sure you have a correct `$GOPATH` set (e.g. add `export GOPATH=$HOME/Go`
+to your `.bashrc`). Also make sure `$GOPATH/bin` is in your `PATH`.
 
-    $ go get github.com/revel/revel
-    $ go get github.com/revel/cmd/revel
-    $ go get github.com/go-sql-driver/mysql
+    $ export PATH=$GOPATH/bin:$PATH
+
+First install [glide](https://glide.sh/) as we use it to lock the dependences.
+It should be in `$GOPATH/bin`.
+
+    $ cd $GOPATH
     $ git clone https://github.com/rofirrim/pingo src/pingo
+    $ cd src/pingo
+    $ glide install
+    $ go install pingo/vendor/github.com/revel/cmd/revel
+
+Revel does not work well with vendored paths so we need to create a soft link
+
+    $ cd $GOPATH/src/pingo
+    $ ln -s $(pwd)/vendor/github.com $GOPATH/src 
 
 To set up the DB
 
@@ -26,7 +38,6 @@ the application will not work.
 
 Local server for development
 
-    $ export PATH=$GOPATH/bin:$PATH
     $ revel run pingo
 
 Now connect to localhost:9000

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,44 @@
+hash: 3b94c921befdf751fc42966e6f05c2126b015a2adf5e14deabf1d83a412f944e
+updated: 2018-01-07T21:14:17.333781042Z
+imports:
+- name: github.com/agtorre/gocolorize
+  version: 99fea4bc9517f07eea8194702cb7076f4845b7de
+- name: github.com/go-sql-driver/mysql
+  version: a0583e0143b1624142adab07e0e97fe106d99561
+- name: github.com/klauspost/compress
+  version: ea08389e0dc46025380296f7dd04ab0e8de36adb
+  subpackages:
+  - flate
+  - gzip
+  - zlib
+- name: github.com/klauspost/cpuid
+  version: ae832f27941af41db13bd6d8efd2493e3b22415a
+- name: github.com/revel/cmd
+  version: 7eda33eb71e8bf504ab43f1ed43583952464edbc
+  subpackages:
+  - revel
+- name: github.com/revel/config
+  version: 662332b741dd464a886ab0901379c02b9bc5dc30
+- name: github.com/revel/modules
+  version: 8c55c9a970cf5062eeb0368e809d6f27cffc28b0
+  subpackages:
+  - static/app/controllers
+  - testrunner/app
+  - testrunner/app/controllers
+- name: github.com/revel/pathtree
+  version: 41257a1839e945fce74afd070e02bab2ea2c776a
+- name: github.com/revel/revel
+  version: 6c8d554fd50278abe4a1c8ad50b811728d5f2a49
+  subpackages:
+  - testing
+- name: golang.org/x/net
+  version: 42fe2e1c20de1054d3d30f82cc9fb5b41e2e3767
+  subpackages:
+  - websocket
+- name: golang.org/x/sys
+  version: dd9ec17814d5b1de388ebe438ec013d57d8b3779
+  subpackages:
+  - unix
+- name: gopkg.in/fsnotify.v1
+  version: 629574ca2a5df945712d3079857300b5e4da0236
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,10 @@
+package: pingo
+import:
+- package: github.com/go-sql-driver/mysql
+  version: 1.3.0
+- package: github.com/revel/modules
+  version: 0.17.0
+- package: github.com/revel/revel
+  version: 0.17.1
+- package: github.com/revel/cmd/revel
+  version: 0.17.0


### PR DESCRIPTION
Note that this is not entirely hassle-free because revel is a bit
special in that it requires an unvendored path. We just create
a soft link for it.